### PR TITLE
Add  support for the remaining sensors from the OI spec, and create request functions to better support encoder outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ adapter.move(0.2, math.radians(0.0))  # go straight
 sleep(1.0)
 adapter.move(0, math.radians(20))  # turn left
 sleep(6.0)
+
+#Print the total distance traveled
+print(f"distance: {adapter.request_distance()} mm, angle: {adapter.request_angle()} rad")
 ```
 
 ## Play song1 
@@ -178,6 +181,8 @@ print(adapter.request_temperature())
 print(adapter.request_charge())
 print(adapter.request_capacity())
 print(adapter.request_oi_mode())
+print(adapter.request_distance())
+print(adapter.request_angle())
 ```
 
 Start a data stream:

--- a/examples/go_and_back.py
+++ b/examples/go_and_back.py
@@ -16,3 +16,6 @@ adapter.move(0.2, math.radians(0.0))  # go straight
 sleep(1.0)
 adapter.move(0, math.radians(20))  # turn left
 sleep(6.0)
+
+#Print the total distance traveled
+print(f"distance: {adapter.request_distance()} mm, angle: {adapter.request_angle()} rad")

--- a/examples/sensors.py
+++ b/examples/sensors.py
@@ -16,6 +16,8 @@ print(adapter.request_temperature())
 print(adapter.request_charge())
 print(adapter.request_capacity())
 print(adapter.request_oi_mode())
+print(adapter.request_distance())
+print(adapter.request_angle())
 
 # Read sensor value from data stream
 adapter.data_stream_start(

--- a/pyroombaadapter/pyroombaadapter.py
+++ b/pyroombaadapter/pyroombaadapter.py
@@ -67,13 +67,55 @@ class PyRoombaAdapter:
 
     SENSOR = {
         # "Name", (Packet ID, Data Bytes, signed)
+        "Wheel Drops": (7, 1, False),
+        "Wall": (8, 1, False),
+        "Cliff Left": (9, 1, False),
+        "Cliff Front Left": (10, 1, False),
+        "Cliff Front Right": (11, 1, False),
+        "Cliff Right": (12, 1, False),
+        "Virtual Wall": (13, 1, False),
+        "Wheel Overcurrent": (14, 1, False),
+        "Dirt Detect": (15, 1, False),
+        "IFR Char Omni": (17, 1, False),
+        "Buttons": (18, 1, False),
+        "Distance": (19, 2, True),
+        "Angle": (20, 2, True),
         "Charging State": (21, 1, False),
         "Voltage": (22, 2, False),
         "Current": (23, 2, True),
         "Temperature": (24, 1, True),
         "Battery Charge": (25, 2, False),
         "Battery Capacity": (26, 2, False),
-        "OI Mode": (35, 1, False)
+        # Wall Signal (packet 27) is depreciated
+        "Cliff Left Signal": (28, 2, False),
+        "Cliff Front Left Signal": (29, 2, False),
+        "Cliff Front Right Signal": (30, 2, False),
+        "Cliff Right Signal": (31, 2, False),
+        "Charging Sources Available": (34, 1, False),
+        "OI Mode": (35, 1, False),
+        "Song Number": (36, 1, False),
+        "Song Playing": (37, 1, False),
+        "Number of Stream Packets": (38, 1, False),
+        "Requested Velocity": (39, 2, True),
+        "Requested Radius": (40, 2, True),
+        "Requested Right Velocity": (41, 2, True),
+        "Requested Left Velocity": (42, 2, True),
+        "Left Encoder Counts": (43, 2, True),
+        "Right Encoder Counts": (44, 2, True),
+        "Light Bumper": (45, 1, False),
+        "Light Bump Left Signal": (46, 2, False),
+        "Light Bump Front Left Signal": (47, 2, False),
+        "Light Bump Front Center Left Signal": (48, 2, False),
+        "Light Bump Front Center Right Signal": (49, 2, False),
+        "Light Bump Front Right Signal": (50, 2, False),
+        "Light Bump Right Signal": (51, 2, False),
+        "IFR Char Left": (52, 1, False),
+        "IFR Char Right": (53, 1, False),
+        "Left Motor Current": (54, 2, True),
+        "Right Motor Current": (55, 2, True),
+        "Main Brush Motor Current": (56, 2, True),
+        "Side Brush Motor Current": (57, 2, True),
+        "Stasis": (58, 1, False)
     }
 
     def __init__(self, port, bau_rate=115200, time_out_sec=1., wheel_span_mm=235.0):
@@ -649,6 +691,41 @@ class PyRoombaAdapter:
         """
         return self._request_sensor("Battery Capacity")
 
+    def request_distance(self):
+        """
+        Requests the Roomba's total distance traveled since it was last checked.
+
+        Returns distance traveled in millimeters (mm) since the distance was last requested. Average between both
+        wheel distances.
+
+        :return: Output range ± 32768 mm
+        """
+        return self._request_sensor("Distance")
+
+    def request_angle(self):
+        """
+        Requests the angular displacement since it was last checked.
+
+        Returns the angle in radians that the Roomba has turned since the angle was last requested.
+        Counter-clockwise is defined positive.
+
+        :return: Output range ± 571.9 rad
+        """
+        # Return a value in radians to remain consistent with the rest of the library
+        return math.radians(self._request_sensor("Angle"))
+
+    def request_encoder_counts(self):
+        """
+        Requests the raw Roomba encoder counts.
+
+        Returns a tuple containing the following: (left count, right count).
+        Linear distance traversed by each wheel is defined by the following:
+        distance = (π * 72.0 / 508.8) * count.
+
+        :return: Output range -32767 - 32768
+        """
+        return (self._request_sensor("Left Encoder Counts"), self._request_sensor("Right Encoder Counts"))
+    
     def request_oi_mode(self):
         """
         requests corrent OI mode

--- a/pyroombaadapter/pyroombaadapter.py
+++ b/pyroombaadapter/pyroombaadapter.py
@@ -722,7 +722,7 @@ class PyRoombaAdapter:
         Linear distance traversed by each wheel is defined by the following:
         distance = (π * 72.0 / 508.8) * count.
 
-        :return: Output range -32767 - 32768
+        :return: A tuple of (left count, right count) in range -32767 - 32768
         """
         return (self._request_sensor("Left Encoder Counts"), self._request_sensor("Right Encoder Counts"))
     


### PR DESCRIPTION
Hi @AtsushiSakai, thanks for this awesome library!

This PR adds the remainder of the sensor packets from the Roomba Open Interface to the Sensors dict, so that they may be queried.
I need to use encoder data for my project, so I also added a few functions to make requesting the distance and angular displacement from the Roomba a bit cleaner. I also updated the examples that I thought were relevant.

I did a couple of tests with my 630 and distance  and angle measurements were low by about 10% (though I do have a non-stock roomba). 

The spec does contain the following note about the distance packet and a similar one is present for the angle packet:

_Create 2 and Roomba 500/600 firmware versions prior to 3.3.0 return an incorrect value for
sensors measured in millimeters. It is recommended that you read the left and right encoder counts
directly (packets IDs 43 and 44) and do the unit conversion yourself._ 

This doesn't effect my Roomba, but in the future if it's of interest I could add a function (or change `request_angle` and `request_distance`) to do the calculation there from the encoder counts so we know it's correct.